### PR TITLE
Option to prevent players from using the parachute while carrying hostage

### DIFF
--- a/src/Parachute.cs
+++ b/src/Parachute.cs
@@ -47,6 +47,7 @@ public class Parachute : BasePlugin, IPluginConfig<ConfigGen>
         {
             Utilities.GetPlayers().ForEach(player =>
             {
+                if (player.IsBot || !player.IsValid) return;
                 bUsingPara.Add(player.UserId, false);
                 gParaTicks.Add(player.UserId, 0);
                 gParaModel.Add(player.UserId, null);
@@ -138,7 +139,7 @@ public class Parachute : BasePlugin, IPluginConfig<ConfigGen>
         {
             var player = @event.Userid;
 
-            if (bUsingPara[player.UserId])
+            if (bUsingPara.ContainsKey(player.UserId) && bUsingPara[player.UserId])
             {
                 bUsingPara[player.UserId] = false;
                 StopPara(player);

--- a/src/Parachute.cs
+++ b/src/Parachute.cs
@@ -17,6 +17,7 @@ public class ConfigGen : BasePluginConfig
     [JsonPropertyName("TeleportTicks")] public int TeleportTicks { get; set; } = 300;
     [JsonPropertyName("ParachuteModelEnabled")] public bool ParachuteModelEnabled { get; set; } = true;
     [JsonPropertyName("ParachuteModel")] public string ParachuteModel { get; set; } = "models/props_survival/parachute/chute.vmdl";
+    [JsonPropertyName("DisableWhenCarryingHostage")] public bool DisableWhenCarryingHostage { get; set; } = false;
 }
 
 [MinimumApiVersion(179)]
@@ -120,7 +121,8 @@ public class Parachute : BasePlugin, IPluginConfig<ConfigGen>
                 && (Config.AccessFlag == "" || AdminManager.PlayerHasPermissions(player, Config.AccessFlag)))
                 {
                     var buttons = player.Buttons;
-                    if ((buttons & PlayerButtons.Use) != 0 && !player.PlayerPawn.Value!.OnGroundLastTick)
+                    var pawn = player.PlayerPawn.Value!;
+                    if ((buttons & PlayerButtons.Use) != 0 && !pawn.OnGroundLastTick && (!Config.DisableWhenCarryingHostage || pawn.HostageServices!.CarriedHostageProp.Value == null))
                     {
                         StartPara(player);
 


### PR DESCRIPTION
Depending on the speed settings, it might be unfair to use the chute while carrying a hostage.

For example, with our settings on the server you could basically instantly bring back the hostage on some maps by using the chute.

Also did some minor fixes. Didn't want to make another branch just for them.